### PR TITLE
Small fix for the inverted class_name and method_name values

### DIFF
--- a/cs-content-generator-sources/src/main/java/io/cloudslang/tools/generator/entities/CsJavaAction.java
+++ b/cs-content-generator-sources/src/main/java/io/cloudslang/tools/generator/entities/CsJavaAction.java
@@ -24,8 +24,8 @@ import java.util.Map;
 public class CsJavaAction implements Mappable {
 
     private final String gav;
-    private final String methodName;
     private final String className;
+    private final String methodName;
 
     public Map<String, Object> toMap() {
         final Map<String, Object> javaActionMap = new HashMap<>();


### PR DESCRIPTION
While using Lombok, the parameters in the AllArgsConstructor are following the order in which they were declared.
All other methods that finally reach the toMap() method of CsJavaAction passes the arguments in the following order: gav, className, methodName.
However, the order of the methodName and className parameters are inverted in the CsJavaAction class, leading to wrong values in the .sl file.